### PR TITLE
Adjust NextAuth session cookie for extension access (SameSite=None, secure conditional)

### DIFF
--- a/src/app/(site_data)/(protected)/done/page.tsx
+++ b/src/app/(site_data)/(protected)/done/page.tsx
@@ -1,0 +1,9 @@
+export default function Done() {
+  return (
+    <main style={{ fontFamily: "sans-serif", padding: 24 }}>
+      <h1>Login complete</h1>
+      <p>You can close this tab.</p>
+    </main>
+  );
+}
+

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,6 +10,15 @@ declare module "next-auth" {
   }
 }
 
+// 推測: HTTPS で運用する本番環境では secure を有効化し、開発時は無効化する。
+const isProd =
+  process.env.NODE_ENV === "production" ||
+  (process.env.NEXTAUTH_URL ?? "").startsWith("https://");
+
+const sessionCookieName = isProd
+  ? "__Secure-authjs.session-token"
+  : "authjs.session-token";
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),
 
@@ -17,6 +26,18 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   session: { strategy: "jwt" },
 
   trustHost: true,
+
+  cookies: {
+    sessionToken: {
+      name: sessionCookieName,
+      options: {
+        httpOnly: true,
+        sameSite: "none",
+        path: "/",
+        secure: isProd,
+      },
+    },
+  },
 
   providers: [
     Google({
@@ -47,4 +68,3 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
   },
 });
-


### PR DESCRIPTION
### Motivation
- Allow browser extensions (cross-site origins like `chrome-extension://`) to send session cookies when calling `/api/auth/session` by setting cookie attributes appropriately.
- Ensure production uses `Secure=true` (HTTPS) while development (`http://localhost`) uses `Secure=false`, and avoid breaking existing JWT strategy and callbacks.

### Description
- Added an `isProd` heuristic that checks `process.env.NODE_ENV` and `process.env.NEXTAUTH_URL` to determine whether to enable `secure` for cookies.
- Introduced an explicit `sessionCookieName` that uses a `__Secure-` prefixed name in production and a simpler name in development to be compatible with security recommendations.
- Configured NextAuth `cookies.sessionToken` to set `sameSite: "none"`, `httpOnly: true`, `path: "/"`, and `secure: isProd` in `src/auth.ts`, while keeping `session.strategy = "jwt"` and preserving existing `jwt`/`session` callbacks.

### Testing
- No automated tests were executed on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698128b4439c832e9ce64726950cd5b4)