### PR TITLE
fix: v1 me ルートの BigInt シリアライズ漏れを修正

### DIFF
--- a/src/app/api/v1/me/favorites/playlists/route.ts
+++ b/src/app/api/v1/me/favorites/playlists/route.ts
@@ -1,5 +1,6 @@
 import { createRouteHandlers } from "@/server/api/handler";
 import { requireUserId } from "@/server/auth/session";
+import { json } from "@/server/http/json";
 import {
   buildCursorPaginationMeta,
   parseCursorPagination,
@@ -30,7 +31,7 @@ export const { GET, POST } = createRouteHandlers({
       },
     );
     const meta = buildCursorPaginationMeta(pagination, hasNext, nextCursor);
-    return Response.json({ data, meta });
+    return json({ data, meta });
   },
   POST: async (req) => {
     const userId = await requireUserId();

--- a/src/app/api/v1/me/route.ts
+++ b/src/app/api/v1/me/route.ts
@@ -1,9 +1,10 @@
 import { createRouteHandlers } from "@/server/api/handler";
 import { requireUser } from "@/server/auth/session";
+import { json } from "@/server/http/json";
 
 export const { GET } = createRouteHandlers({
   GET: async () => {
     const user = await requireUser();
-    return Response.json(user);
+    return json(user);
   },
 });

--- a/src/app/api/v1/me/vods/route.ts
+++ b/src/app/api/v1/me/vods/route.ts
@@ -1,5 +1,6 @@
 import { createRouteHandlers } from "@/server/api/handler";
 import { requireUserId } from "@/server/auth/session";
+import { json } from "@/server/http/json";
 import {
   buildCursorPaginationMeta,
   parseCursorPagination,
@@ -22,7 +23,7 @@ export const { GET, POST } = createRouteHandlers({
       limit: pagination.limit,
     });
     const meta = buildCursorPaginationMeta(pagination, hasNext, nextCursor);
-    return Response.json({ data, meta });
+    return json({ data, meta });
   },
   POST: async (req) => {
     const userId = await requireUserId();


### PR DESCRIPTION
Fixes #31

## 変更内容

`/api/v1/me` 系3ルートで `Response.json()` を直接使用していた箇所を、プロジェクト標準の `json()` ヘルパーに統一。

## 修正ファイル

- `src/app/api/v1/me/route.ts`
- `src/app/api/v1/me/favorites/playlists/route.ts`
- `src/app/api/v1/me/vods/route.ts`

## テスト確認

- [ ] TypeScript 型チェック通過