### PR TITLE
fix: ページの直接 Prisma 呼び出しをサービス経由に移行

### DIFF
--- a/src/app/(site_data)/(protected)/account/page.tsx
+++ b/src/app/(site_data)/(protected)/account/page.tsx
@@ -1,8 +1,7 @@
 import "@/app/globals.css";
 import { redirect } from "next/navigation";
-import { auth } from "@/auth";
 import { ExtensionLinkButton } from "@/components/ExtensionLinkButton";
-import { prisma } from "@/server/db";
+import { getCurrentUser } from "@/server/auth/session";
 import {
   collectSubscriptionServices,
   formatDateJa,
@@ -12,35 +11,15 @@ import {
 export const dynamic = "force-dynamic";
 
 export default async function AccountPage() {
-  const session = await auth();
-
-  if (!session?.user?.id) {
-    redirect("/login");
-  }
-
-  const dbUser = await prisma.user.findUnique({
-    where: { id: BigInt(session.user.id) },
-    select: {
-      name: true,
-      email: true,
-      createdAt: true,
-      playlists: {
-        select: { id: true },
-      },
-    },
+  const dbUser = await getCurrentUser({
+    name: true,
+    email: true,
+    createdAt: true,
+    playlists: { select: { id: true } },
   });
 
   if (!dbUser) {
-    return (
-      <main className="main-content">
-        <section className="user-info">
-          <h3>ユーザー情報</h3>
-          <p>
-            ユーザー情報の取得に失敗しました。時間をおいて再読み込みしてください。
-          </p>
-        </section>
-      </main>
-    );
+    redirect("/login");
   }
 
   const subscriptionServices = collectSubscriptionServices([]);

--- a/src/app/(site_data)/(protected)/dashboard/page.tsx
+++ b/src/app/(site_data)/(protected)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 import { signIn, signOut } from "@/auth";
 import { getCurrentUser, getSession } from "@/server/auth/session";
-import { prisma } from "@/server/db";
+import { getUserAuthInfo } from "@/server/services/users";
 
 export const dynamic = "force-dynamic";
 
@@ -31,28 +31,7 @@ export default async function DashboardPage() {
     );
   }
 
-  const [accounts, sessions] = await Promise.all([
-    prisma.account.findMany({
-      where: { userId: currentUser.id },
-      orderBy: { id: "asc" },
-      select: {
-        id: true,
-        provider: true,
-        providerAccountId: true,
-        type: true,
-        scope: true,
-        expiresAt: true,
-      },
-    }),
-    prisma.session.findMany({
-      where: { userId: currentUser.id },
-      orderBy: { expires: "desc" },
-      select: {
-        id: true,
-        expires: true,
-      },
-    }),
-  ]);
+  const { accounts, sessions } = await getUserAuthInfo(Number(currentUser.id));
 
   return (
     <main className="main-content">

--- a/src/app/(site_data)/(protected)/playlists/[playlistId]/page.tsx
+++ b/src/app/(site_data)/(protected)/playlists/[playlistId]/page.tsx
@@ -2,8 +2,8 @@
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
-import { auth } from "@/auth";
-import { prisma } from "@/lib/prisma";
+import { getCurrentUser } from "@/server/auth/session";
+import { getPlaylistWithClips } from "@/server/services/playlists";
 import PlaylistView from "./PlaylistView.client";
 
 type PlaylistPageProps = {
@@ -13,28 +13,12 @@ type PlaylistPageProps = {
 export default async function PlaylistPage({ params }: PlaylistPageProps) {
   const { playlistId } = await params;
 
-  const session = await auth();
-  const userId = session?.user?.id ?? null;
+  const [currentUser, playlist] = await Promise.all([
+    getCurrentUser({ id: true }),
+    getPlaylistWithClips(Number(playlistId)).catch(() => null),
+  ]);
 
-  const playlist = await prisma.playlist.findUnique({
-    where: { id: Number(playlistId) },
-    select: {
-      id: true,
-      name: true,
-      userId: true,
-      clipsPlaylists: {
-        orderBy: { createdAt: "desc" },
-        include: {
-          clip: {
-            include: {
-              user: true,
-              vod: true,
-            },
-          },
-        },
-      },
-    },
-  });
+  const userId = currentUser ? String(currentUser.id) : null;
 
   if (!playlist) return <div>Not Found</div>;
 

--- a/src/app/(site_data)/(protected)/playlists/[playlistId]/page.tsx
+++ b/src/app/(site_data)/(protected)/playlists/[playlistId]/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
 import { getCurrentUser } from "@/server/auth/session";
+import { isNotFoundError } from "@/server/http/errors";
 import { getPlaylistWithClips } from "@/server/services/playlists";
 import PlaylistView from "./PlaylistView.client";
 
@@ -15,7 +16,10 @@ export default async function PlaylistPage({ params }: PlaylistPageProps) {
 
   const [currentUser, playlist] = await Promise.all([
     getCurrentUser({ id: true }),
-    getPlaylistWithClips(Number(playlistId)).catch(() => null),
+    getPlaylistWithClips(Number(playlistId)).catch((err) => {
+      if (isNotFoundError(err)) return null;
+      throw err;
+    }),
   ]);
 
   const userId = currentUser ? String(currentUser.id) : null;

--- a/src/app/(site_data)/clipAppRouter/[id]/page.js
+++ b/src/app/(site_data)/clipAppRouter/[id]/page.js
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { prisma } from "@/lib/prisma";
+import { getClipWithVod } from "@/server/services/clips";
 
 export const dynamic = "force-dynamic";
 
@@ -8,10 +8,7 @@ export default async function ClipPage({ params }) {
 
   if (!id) return <h1>Missing ID</h1>;
 
-  const clip = await prisma.clip.findFirst({
-    where: { id: Number(id), deletedAt: null },
-    include: { vod: true },
-  });
+  const clip = await getClipWithVod(Number(id)).catch(() => null);
 
   if (!clip) return <h1>Not Found</h1>;
 

--- a/src/app/(site_data)/clipAppRouter/[id]/page.js
+++ b/src/app/(site_data)/clipAppRouter/[id]/page.js
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { isNotFoundError } from "@/server/http/errors";
 import { getClipWithVod } from "@/server/services/clips";
 
 export const dynamic = "force-dynamic";
@@ -8,7 +9,10 @@ export default async function ClipPage({ params }) {
 
   if (!id) return <h1>Missing ID</h1>;
 
-  const clip = await getClipWithVod(Number(id)).catch(() => null);
+  const clip = await getClipWithVod(Number(id)).catch((err) => {
+    if (isNotFoundError(err)) return null;
+    throw err;
+  });
 
   if (!clip) return <h1>Not Found</h1>;
 

--- a/src/server/http/errors.ts
+++ b/src/server/http/errors.ts
@@ -62,6 +62,10 @@ export class NotFoundError extends HttpError {
   }
 }
 
+export function isNotFoundError(err: unknown): err is NotFoundError {
+  return err instanceof NotFoundError;
+}
+
 export class ConflictError extends HttpError {
   constructor(message = "Conflict", code = "CONFLICT", details?: unknown) {
     super(409, message, code, details);

--- a/src/server/repositories/clips.ts
+++ b/src/server/repositories/clips.ts
@@ -6,6 +6,13 @@ export function findById(id: number) {
   return prisma.clip.findFirst({ where: { id, deletedAt: null } });
 }
 
+export function findByIdWithVod(id: number) {
+  return prisma.clip.findFirst({
+    where: { id, deletedAt: null },
+    include: { vod: true },
+  });
+}
+
 export async function list(
   opts: {
     skip?: number;

--- a/src/server/repositories/playlists.ts
+++ b/src/server/repositories/playlists.ts
@@ -6,6 +6,28 @@ export function findById(id: number) {
   return prisma.playlist.findFirst({ where: { id, deletedAt: null } });
 }
 
+export function findWithClips(id: number) {
+  return prisma.playlist.findFirst({
+    where: { id, deletedAt: null },
+    select: {
+      id: true,
+      name: true,
+      userId: true,
+      clipsPlaylists: {
+        orderBy: { createdAt: "desc" },
+        include: {
+          clip: {
+            include: {
+              user: true,
+              vod: true,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
 export async function list(
   opts: {
     skip?: number;

--- a/src/server/repositories/users.ts
+++ b/src/server/repositories/users.ts
@@ -145,3 +145,29 @@ export async function removeUserVod(userId: number, vodId: number) {
   const result = await prisma.userVod.deleteMany({ where: { userId, vodId } });
   return result.count;
 }
+
+export async function getUserAuthInfo(userId: number) {
+  const [accounts, sessions] = await Promise.all([
+    prisma.account.findMany({
+      where: { userId },
+      orderBy: { id: "asc" },
+      select: {
+        id: true,
+        provider: true,
+        providerAccountId: true,
+        type: true,
+        scope: true,
+        expiresAt: true,
+      },
+    }),
+    prisma.session.findMany({
+      where: { userId },
+      orderBy: { expires: "desc" },
+      select: {
+        id: true,
+        expires: true,
+      },
+    }),
+  ]);
+  return { accounts, sessions };
+}

--- a/src/server/services/clips.ts
+++ b/src/server/services/clips.ts
@@ -15,6 +15,12 @@ export async function getClip(id: number) {
   return clip;
 }
 
+export async function getClipWithVod(id: number) {
+  const clip = await repo.findByIdWithVod(id);
+  if (!clip) throw new NotFoundError("Clip not found");
+  return clip;
+}
+
 export function createClip(
   currentUserId: number,
   data: Omit<Parameters<typeof repo.create>[0], "userId">,

--- a/src/server/services/playlists.ts
+++ b/src/server/services/playlists.ts
@@ -21,6 +21,12 @@ export async function getPlaylist(id: number) {
   return playlist;
 }
 
+export async function getPlaylistWithClips(id: number) {
+  const playlist = await repo.findWithClips(id);
+  if (!playlist) throw new NotFoundError("Playlist not found");
+  return playlist;
+}
+
 export function createPlaylist(
   currentUserId: number,
   data: Omit<Parameters<typeof repo.create>[0], "userId">,

--- a/src/server/services/users.ts
+++ b/src/server/services/users.ts
@@ -9,6 +9,10 @@ export function listUsers(opts: Parameters<typeof repo.list>[0]) {
   return repo.list(opts);
 }
 
+export function getUserAuthInfo(userId: number) {
+  return repo.getUserAuthInfo(userId);
+}
+
 export async function getUser(id: number) {
   const user = await repo.findById(id);
   if (!user) throw new NotFoundError("User not found");


### PR DESCRIPTION
Fixes #33

## 変更内容

### リポジトリ層
- `repositories/clips.ts` — `findByIdWithVod()` 追加
- `repositories/playlists.ts` — `findWithClips()` 追加
- `repositories/users.ts` — `getUserAuthInfo()` 追加（accounts + sessions）

### サービス層
- `services/clips.ts` — `getClipWithVod()` 追加
- `services/playlists.ts` — `getPlaylistWithClips()` 追加
- `services/users.ts` — `getUserAuthInfo()` 追加

### ページ層
- `account/page.tsx` — `await auth()` + `prisma.user` → `getCurrentUser(select)`
- `dashboard/page.tsx` — `prisma.account/session` → `getUserAuthInfo()` サービス
- `playlists/[id]/page.tsx` — `prisma.playlist` → `getPlaylistWithClips()`、`@/lib/prisma` を除去
- `clipAppRouter/[id]/page.js` — `prisma.clip` → `getClipWithVod()`、`@/lib/prisma` を除去

## テスト確認

- [x] TypeScript 型チェック通過（`npx tsc --noEmit` エラーなし）