### PR TITLE
chore: .claude/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,7 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# Claude Code
+.claude/
+
 /generated/prisma


### PR DESCRIPTION
## 概要

`.claude/` ディレクトリ（Claude Code の設定・カスタムコマンド等）をリポジトリの追跡対象から除外する。

各開発者の Claude Code 設定はローカル固有のものであり、コードベースに含める必要はない。