### PR TITLE
refactor: accountViewModel.mjs を .ts に変換して TypeScript 型を追加

### DIFF
--- a/src/app/(site_data)/(protected)/account/accountViewModel.ts
+++ b/src/app/(site_data)/(protected)/account/accountViewModel.ts
@@ -1,6 +1,10 @@
 // biome-ignore-all lint/security/noSecrets: Japanese fallback UI text is a false positive.
 
-export function formatDateJa(value) {
+interface ClipLike {
+  service?: string | null;
+}
+
+export function formatDateJa(value: Date): string {
   return new Intl.DateTimeFormat("ja-JP", {
     year: "numeric",
     month: "2-digit",
@@ -8,18 +12,18 @@ export function formatDateJa(value) {
   }).format(value);
 }
 
-export function collectSubscriptionServices(clips) {
+export function collectSubscriptionServices(clips: ClipLike[]): string[] {
   return Array.from(
     new Set(
       clips
         .map((clip) => clip.service)
-        .filter((service) => typeof service === "string")
+        .filter((service): service is string => typeof service === "string")
         .map((service) => service.trim())
         .filter(Boolean),
     ),
   );
 }
 
-export function formatSubscriptionLabel(services) {
+export function formatSubscriptionLabel(services: string[]): string {
   return services.length > 0 ? services.join(" / ") : "未連携（仮表示）";
 }

--- a/src/app/(site_data)/(protected)/account/page.tsx
+++ b/src/app/(site_data)/(protected)/account/page.tsx
@@ -6,7 +6,7 @@ import {
   collectSubscriptionServices,
   formatDateJa,
   formatSubscriptionLabel,
-} from "./accountViewModel.mjs";
+} from "./accountViewModel";
 
 export const dynamic = "force-dynamic";
 

--- a/tests/account/accountViewModel.test.mjs
+++ b/tests/account/accountViewModel.test.mjs
@@ -6,7 +6,7 @@ import {
   collectSubscriptionServices,
   formatDateJa,
   formatSubscriptionLabel,
-} from "../../src/app/(site_data)/(protected)/account/accountViewModel.mjs";
+} from "../../src/app/(site_data)/(protected)/account/accountViewModel.ts";
 
 test("collectSubscriptionServices removes blanks and duplicates", () => {
   const clips = [


### PR DESCRIPTION
Node 24 のネイティブ TS サポートにより test runner でも .ts を直接 import 可能。 .mjs は Next.js プロジェクトでは不適切なため .ts に統一。


closes #41 

